### PR TITLE
OAuth Code for Google/YouTube

### DIFF
--- a/realm/functions/get_token/config.json
+++ b/realm/functions/get_token/config.json
@@ -1,0 +1,6 @@
+{
+    "id": "5ff83a65ba6ad00b709b3659",
+    "name": "get_token",
+    "private": true,
+    "run_as_system": true
+}

--- a/realm/functions/get_token/source.js
+++ b/realm/functions/get_token/source.js
@@ -1,0 +1,48 @@
+exports = async function(){
+  const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+  const CLIENT_ID = context.values.get("GOOGLE_CLIENT_ID");
+  const CLIENT_SECRET = context.values.get("GOOGLE_CLIENT_SECRET");
+  
+  const tokens_collection = context.services.get("mongodb-atlas").db("auth").collection("auth_tokens");
+  
+  // Look up tokens:
+  let tokens = await tokens_collection.findOne({_id: "youtube"});
+  if (new Date() >= tokens.expires_at) {
+    // access_token has expired. Get a new one.
+    let res = await context.http.post({
+      url: GOOGLE_TOKEN_ENDPOINT,
+      body: {
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+      },
+      encodeBodyAsJSON: true,
+    });
+    
+    tokens = JSON.parse(res.body.text());
+    
+    // TODO: Need to handle error responses here!
+    
+    tokens.updated = new Date();
+    tokens.expires_at = new Date();
+    tokens.expires_at.setTime(Date.now() + (tokens.expires_in * 1000));
+    
+    await tokens_collection.updateOne(
+      {
+        _id: "youtube"
+      }, 
+      {
+        $set: { 
+          access_token: tokens.access_token,
+          expires_at: tokens.expires_at,
+          expires_in: tokens.expires_in,
+          updated: tokens.updated,
+        },
+      },
+    );
+  }
+  
+  return tokens.access_token
+};

--- a/realm/functions/get_token/source.js
+++ b/realm/functions/get_token/source.js
@@ -1,13 +1,13 @@
-exports = async function(){
+exports = async function () {
   const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 
   const CLIENT_ID = context.values.get("GOOGLE_CLIENT_ID");
   const CLIENT_SECRET = context.values.get("GOOGLE_CLIENT_SECRET");
-  
+
   const tokens_collection = context.services.get("mongodb-atlas").db("auth").collection("auth_tokens");
-  
+
   // Look up tokens:
-  let tokens = await tokens_collection.findOne({_id: "youtube"});
+  let tokens = await tokens_collection.findOne({ _id: "youtube" });
   if (new Date() >= tokens.expires_at) {
     // access_token has expired. Get a new one.
     let res = await context.http.post({
@@ -20,21 +20,21 @@ exports = async function(){
       },
       encodeBodyAsJSON: true,
     });
-    
+
     tokens = JSON.parse(res.body.text());
-    
+
     // TODO: Need to handle error responses here!
-    
+
     tokens.updated = new Date();
     tokens.expires_at = new Date();
     tokens.expires_at.setTime(Date.now() + (tokens.expires_in * 1000));
-    
+
     await tokens_collection.updateOne(
       {
         _id: "youtube"
-      }, 
+      },
       {
-        $set: { 
+        $set: {
           access_token: tokens.access_token,
           expires_at: tokens.expires_at,
           expires_in: tokens.expires_in,
@@ -43,6 +43,6 @@ exports = async function(){
       },
     );
   }
-  
+
   return tokens.access_token
 };

--- a/realm/services/google_oauth/config.json
+++ b/realm/services/google_oauth/config.json
@@ -1,0 +1,7 @@
+{
+    "id": "5f730830e98b002dac5a6f61",
+    "name": "google_oauth",
+    "type": "http",
+    "config": {},
+    "version": 1
+}

--- a/realm/services/google_oauth/incoming_webhooks/oauth/config.json
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/config.json
@@ -1,0 +1,14 @@
+{
+    "id": "5f73085f50b8cd75abd95c66",
+    "name": "oauth",
+    "run_as_authed_user": false,
+    "run_as_user_id": "",
+    "run_as_user_id_script_source": "",
+    "options": {
+        "httpMethod": "GET",
+        "validationMethod": "NO_VALIDATION"
+    },
+    "respond_result": true,
+    "fetch_custom_user_data": false,
+    "create_user_on_auth": false
+}

--- a/realm/services/google_oauth/incoming_webhooks/oauth/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/source.js
@@ -1,17 +1,11 @@
 
-exports = async function(payload, response) {
-  const https = require('https');
+exports = async function (payload, response) {
   const querystring = require('querystring');
-  const url = require('url');
-  
-  // MongoDBofficial Channel ID:
-  // (Obtained from: https://www.youtube.com/account_advanced)
-  const ACCOUNT_ID = context.values.get("GOOGLE_ACCOUNT_ID"); //"UCK_m2976Yvbx-TyDLw7n1WA";
-  
+
   // Following obtained from: https://console.developers.google.com/apis/credentials
   const CLIENT_ID = context.values.get("GOOGLE_CLIENT_ID");
   const CLIENT_SECRET = context.values.get("GOOGLE_CLIENT_SECRET");
-  
+
   // TODO: Can probably generate the following programmatically:
   const OAUTH2_CALLBACK = context.request.webhookUrl;
 
@@ -32,9 +26,9 @@ exports = async function(payload, response) {
     "https://www.googleapis.com/auth/youtubepartner",
     "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
     "https://www.googleapis.com/auth/yt-analytics.readonly"
-    ];
+  ];
 
-  
+
   const error = payload.query.error;
   if (typeof error !== 'undefined') {
     // Google says there's a problem:
@@ -53,9 +47,7 @@ exports = async function(payload, response) {
         'scope': SCOPES.join(' '),
         'access_type': "offline",
       });
-      
-      console.log("Redirecting to:", oauthURL.href.substring(oauthURL.href.length - 100));
-  
+
       response.setStatusCode(302);
       response.setHeader('Location', oauthURL.href);
     } else {
@@ -72,24 +64,24 @@ exports = async function(payload, response) {
         },
         encodeBodyAsJSON: true,
       });
-      
+
       // TODO: Need to handle errors here!
-      
+
       let tokens = JSON.parse(res.body.text());
       tokens.updated = new Date();
       tokens.expires_at = new Date();
       tokens.expires_at.setTime(Date.now() + (tokens.expires_in * 1000));
-      
+
       await context.services.get("mongodb-atlas").db("auth").collection("auth_tokens").findOneAndReplace(
         {
           _id: "youtube"
-        }, 
+        },
         tokens,
         {
           upsert: true,
         },
       );
-      
+
       return {
         "message": "ok",
       }

--- a/realm/services/google_oauth/incoming_webhooks/oauth/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/source.js
@@ -1,17 +1,17 @@
 
-exports = async function (payload, response) {
+exports = async function(payload, response) {
   const https = require('https');
   const querystring = require('querystring');
   const url = require('url');
-
+  
   // MongoDBofficial Channel ID:
-  // (Obtained from: https://developers.google.com/youtube/v3/docs/channels/list?apix=true&apix_params=%7B%22part%22%3A%5B%22id%22%5D%2C%22forUsername%22%3A%22MongoDB%22%7D)
+  // (Obtained from: https://www.youtube.com/account_advanced)
   const ACCOUNT_ID = context.values.get("GOOGLE_ACCOUNT_ID"); //"UCK_m2976Yvbx-TyDLw7n1WA";
-
+  
   // Following obtained from: https://console.developers.google.com/apis/credentials
   const CLIENT_ID = context.values.get("GOOGLE_CLIENT_ID");
   const CLIENT_SECRET = context.values.get("GOOGLE_CLIENT_SECRET");
-
+  
   // TODO: Can probably generate the following programmatically:
   const OAUTH2_CALLBACK = context.request.webhookUrl;
 
@@ -32,9 +32,9 @@ exports = async function (payload, response) {
     "https://www.googleapis.com/auth/youtubepartner",
     "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
     "https://www.googleapis.com/auth/yt-analytics.readonly"
-  ];
+    ];
 
-
+  
   const error = payload.query.error;
   if (typeof error !== 'undefined') {
     // Google says there's a problem:
@@ -51,8 +51,11 @@ exports = async function (payload, response) {
         'redirect_uri': OAUTH2_CALLBACK,
         'response_type': 'code',
         'scope': SCOPES.join(' '),
+        'access_type': "offline",
       });
-
+      
+      console.log("Redirecting to:", oauthURL.href.substring(oauthURL.href.length - 100));
+  
       response.setStatusCode(302);
       response.setHeader('Location', oauthURL.href);
     } else {
@@ -66,31 +69,30 @@ exports = async function (payload, response) {
           code: oauthCode,
           grant_type: 'authorization_code',
           redirect_uri: OAUTH2_CALLBACK,
-          access_type: "offline",
         },
         encodeBodyAsJSON: true,
       });
+      
+      // TODO: Need to handle errors here!
+      
       let tokens = JSON.parse(res.body.text());
-      tokens._id = "youtube";
-
-      const doc = await context.services.get("mongodb-atlas").db("auth").collection("auth_tokens").findOneAndReplace(
+      tokens.updated = new Date();
+      tokens.expires_at = new Date();
+      tokens.expires_at.setTime(Date.now() + (tokens.expires_in * 1000));
+      
+      await context.services.get("mongodb-atlas").db("auth").collection("auth_tokens").findOneAndReplace(
         {
           _id: "youtube"
-        },
+        }, 
         tokens,
         {
           upsert: true,
         },
       );
-
+      
       return {
         "message": "ok",
       }
     }
   }
-
-  // Querying a mongodb service:
-  // const doc = context.services.get("mongodb-atlas").db("dbname").collection("coll_name").findOne();
-
-
 };

--- a/realm/services/google_oauth/incoming_webhooks/oauth/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/source.js
@@ -1,0 +1,129 @@
+// This function is the webhook's request handler.
+exports = async function (payload, response) {
+  const https = require('https');
+  const querystring = require('querystring');
+  const url = require('url');
+
+  // MongoDBofficial Channel ID:
+  // (Obtained from: https://developers.google.com/youtube/v3/docs/channels/list?apix=true&apix_params=%7B%22part%22%3A%5B%22id%22%5D%2C%22forUsername%22%3A%22MongoDB%22%7D)
+  const ACCOUNT_ID = context.values.get("GOOGLE_ACCOUNT_ID");
+
+  // Following obtained from: https://console.developers.google.com/apis/credentials
+  const CLIENT_ID = context.values.get("GOOGLE_CLIENT_ID");
+  const CLIENT_SECRET = context.values.get("GOOGLE_CLIENT_SECRET");
+
+  // TODO: Can probably generate the following programmatically:
+  const OAUTH2_CALLBACK = "https://webhooks.mongodb-realm.com/api/client/v2.0/app/dream-scratch-ermjp/service/google_oauth/incoming_webhook/oauth";
+
+  // This shouldn't change:
+  // https://developers.google.com/youtube/v3/guides/auth/server-side-web-apps#httprest
+  const GOOGLE_OAUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+  const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+  const SCOPES = [
+    "https://www.googleapis.com/auth/youtube",
+    "https://www.googleapis.com/auth/youtube.readonly",
+    "https://www.googleapis.com/auth/youtubepartner",
+    "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
+    "https://www.googleapis.com/auth/yt-analytics.readonly",
+    "https://www.googleapis.com/auth/youtube",
+    "https://www.googleapis.com/auth/youtube.force-ssl",
+    "https://www.googleapis.com/auth/youtube.readonly",
+    "https://www.googleapis.com/auth/youtubepartner",
+    "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
+    "https://www.googleapis.com/auth/yt-analytics.readonly"
+  ];
+
+
+  const error = payload.query.error;
+  if (typeof error !== 'undefined') {
+    // Google says there's a problem:
+    console.error("Error code returned from Google:", error);
+    response.setHeader('Content-Type', 'text/plain');
+    response.setBody(error);
+  } else {
+    const oauthCode = payload.query.code;
+    if (typeof oauthCode === 'undefined') {
+      // No code provided, so let's request one from Google:
+      const oauthURL = new URL(GOOGLE_OAUTH_ENDPOINT);
+      oauthURL.search = querystring.stringify({
+        'client_id': CLIENT_ID,
+        'redirect_uri': OAUTH2_CALLBACK,
+        'response_type': 'code',
+        'scope': SCOPES.join(' '),
+      });
+
+      response.setStatusCode(302);
+      response.setHeader('Location', oauthURL.href);
+    } else {
+      // We have a code, so we've redirected successfully from Google's consent page.
+      // Let's post to Google, requesting an access:
+
+      const poster = new Promise((resolve, reject) => {
+        const bodyObject = {
+          client_id: CLIENT_ID,
+          client_secret: CLIENT_SECRET,
+          code: oauthCode,
+          grant_type: 'authorization_code',
+          redirect_uri: OAUTH2_CALLBACK,
+        };
+
+        const req = https.request(
+          GOOGLE_TOKEN_ENDPOINT,
+          {
+            method: 'POST',
+          },
+          (res) => {
+            let rawData = '';
+            res.on('data', (chunk) => { rawData += chunk; });
+            res.on('end', () => {
+              try {
+                const parsedData = JSON.parse(rawData);
+                resolve(parsedData);
+              } catch (e) {
+                reject(e.message);
+              }
+            });
+          }
+        );
+        req.on('error', () => {
+          reject(e);
+        });
+        req.write(JSON.stringify(bodyObject));
+        req.end();
+      });
+
+      let tokens = await poster;
+
+      // Just for giggles, let's use the token to make a request:
+      const requester = new Promise((resolve, reject) => {
+        const req = https.get(
+          'https://www.googleapis.com/youtube/v3/channels?part=snippet%2CcontentDetails%2Cstatistics&forUsername=MongoDB&prettyPrint=true',
+          {
+            headers: {
+              'Authorization': `Bearer ${tokens.access_token}`,
+              'Accept': 'application/json'
+            }
+          },
+          (res) => {
+            let rawData = '';
+            res.on('data', (chunk) => { rawData += chunk; });
+            res.on('end', () => {
+              resolve(rawData);
+            });
+          });
+        req.on('error', () => {
+          reject(e);
+        });
+      });
+      const data = await requester;
+      response.setHeader('Content-Type', 'text/plain');
+      response.setBody(data);
+    }
+  }
+
+  // Querying a mongodb service:
+  // const doc = context.services.get("mongodb-atlas").db("dbname").collection("coll_name").findOne();
+
+
+};

--- a/realm/services/google_oauth/incoming_webhooks/oauth/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/source.js
@@ -13,7 +13,7 @@ exports = async function (payload, response) {
   const CLIENT_SECRET = context.values.get("GOOGLE_CLIENT_SECRET");
 
   // TODO: Can probably generate the following programmatically:
-  const OAUTH2_CALLBACK = "https://webhooks.mongodb-realm.com/api/client/v2.0/app/dream-scratch-ermjp/service/google_oauth/incoming_webhook/oauth";
+  const OAUTH2_CALLBACK = context.request.webhookUrl;
 
   // This shouldn't change:
   // https://developers.google.com/youtube/v3/guides/auth/server-side-web-apps#httprest

--- a/realm/services/google_oauth/incoming_webhooks/oauth/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/source.js
@@ -66,6 +66,7 @@ exports = async function (payload, response) {
           code: oauthCode,
           grant_type: 'authorization_code',
           redirect_uri: OAUTH2_CALLBACK,
+          access_type: "offline",
         },
         encodeBodyAsJSON: true,
       });

--- a/realm/services/google_oauth/incoming_webhooks/oauth/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/oauth/source.js
@@ -124,6 +124,4 @@ exports = async function (payload, response) {
 
   // Querying a mongodb service:
   // const doc = context.services.get("mongodb-atlas").db("dbname").collection("coll_name").findOne();
-
-
 };

--- a/realm/services/google_oauth/incoming_webhooks/test/config.json
+++ b/realm/services/google_oauth/incoming_webhooks/test/config.json
@@ -1,6 +1,6 @@
 {
-    "id": "5f73085f50b8cd75abd95c66",
-    "name": "oauth",
+    "id": "5ff848b4372c6b244c07754c",
+    "name": "test",
     "run_as_authed_user": false,
     "run_as_user_id": "",
     "run_as_user_id_script_source": "",

--- a/realm/services/google_oauth/incoming_webhooks/test/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/test/source.js
@@ -1,0 +1,16 @@
+exports = async function(payload, response) {
+    // Get a token (it'll be refreshed if necessary):
+    const accessToken = await context.functions.execute("get_token");
+    
+    // Make an authenticated call:
+    const result = await context.http.get({
+      url: 'https://www.googleapis.com/youtube/v3/channels?part=snippet%2CcontentDetails%2Cstatistics&forUsername=MongoDB&prettyPrint=true',
+      headers: {
+        'Authorization': [`Bearer ${accessToken}`],
+        'Accept': ['application/json'],
+      },
+    });
+    
+    response.setHeader('Content-Type', 'text/plain');
+    response.setBody(result.body.text());
+};

--- a/realm/services/google_oauth/incoming_webhooks/test/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/test/source.js
@@ -1,16 +1,16 @@
-exports = async function(payload, response) {
-    // Get a token (it'll be refreshed if necessary):
-    const accessToken = await context.functions.execute("get_token");
-    
-    // Make an authenticated call:
-    const result = await context.http.get({
-      url: 'https://www.googleapis.com/youtube/v3/channels?part=snippet%2CcontentDetails%2Cstatistics&forUsername=MongoDB&prettyPrint=true',
-      headers: {
-        'Authorization': [`Bearer ${accessToken}`],
-        'Accept': ['application/json'],
-      },
-    });
-    
-    response.setHeader('Content-Type', 'text/plain');
-    response.setBody(result.body.text());
+exports = async function (payload, response) {
+  // Get a token (it'll be refreshed if necessary):
+  const accessToken = await context.functions.execute("get_token");
+
+  // Make an authenticated call:
+  const result = await context.http.get({
+    url: 'https://www.googleapis.com/youtube/v3/channels?part=snippet%2CcontentDetails%2Cstatistics&forUsername=MongoDB&prettyPrint=true',
+    headers: {
+      'Authorization': [`Bearer ${accessToken}`],
+      'Accept': ['application/json'],
+    },
+  });
+
+  response.setHeader('Content-Type', 'text/plain');
+  response.setBody(result.body.text());
 };

--- a/realm/services/google_oauth/incoming_webhooks/url_constructor/config.json
+++ b/realm/services/google_oauth/incoming_webhooks/url_constructor/config.json
@@ -1,6 +1,6 @@
 {
-    "id": "5f73085f50b8cd75abd95c66",
-    "name": "oauth",
+    "id": "5f89663cf69fd9e2419aaa75",
+    "name": "url_constructor",
     "run_as_authed_user": false,
     "run_as_user_id": "",
     "run_as_user_id_script_source": "",
@@ -10,6 +10,7 @@
         "validationMethod": "NO_VALIDATION"
     },
     "respond_result": true,
+    "disable_arg_logs": true,
     "fetch_custom_user_data": false,
     "create_user_on_auth": false
 }

--- a/realm/services/google_oauth/incoming_webhooks/url_constructor/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/url_constructor/source.js
@@ -1,9 +1,9 @@
 // This function is the webhook's request handler.
-exports = function(payload, response) {
-    let url = context.request.webhookUrl;
-    if (context.request.rawQueryString !== undefined) {
-      url += "?" + context.request.rawQueryString;
-    }
-    
-    return url;
+exports = function (payload, response) {
+  let url = context.request.webhookUrl;
+  if (context.request.rawQueryString !== undefined) {
+    url += "?" + context.request.rawQueryString;
+  }
+
+  return url;
 };

--- a/realm/services/google_oauth/incoming_webhooks/url_constructor/source.js
+++ b/realm/services/google_oauth/incoming_webhooks/url_constructor/source.js
@@ -1,0 +1,9 @@
+// This function is the webhook's request handler.
+exports = function(payload, response) {
+    let url = context.request.webhookUrl;
+    if (context.request.rawQueryString !== undefined) {
+      url += "?" + context.request.rawQueryString;
+    }
+    
+    return url;
+};

--- a/realm/values/google_account_id.json
+++ b/realm/values/google_account_id.json
@@ -1,0 +1,5 @@
+{
+    "name": "GOOGLE_ACCOUNT_ID",
+    "from_secret": false,
+    "value": "UCK_m2976Yvbx-TyDLw7n1WA"
+}

--- a/realm/values/google_client_id.json
+++ b/realm/values/google_client_id.json
@@ -1,0 +1,5 @@
+{
+    "name": "GOOGLE_CLIENT_ID",
+    "from_secret": false,
+    "value": "dummy-value"
+}

--- a/realm/values/google_client_secret.json
+++ b/realm/values/google_client_secret.json
@@ -1,0 +1,5 @@
+{
+    "name": "GOOGLE_CLIENT_SECRET",
+    "from_secret": true,
+    "value": "dummy-value"
+}


### PR DESCRIPTION
If you've already linked the MongoDB YouTube account with your Google App, then you've missed the chance to get a refresh token. You'll need to [revoke your token](https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke)

In order to revoke your token, you'll need a valid access token. If you have one of these, skip to [revoke your token](#revoke-your-token), if not...

## Obtain an access token
Go to your oauth webhook, and follow the steps to authorize access to the MongoDB YouTube account. When you see `{"message":"ok"}` you've completed the process 🙂 

## Revoke your token
Now load up your collections in Atlas, and look in `auth.auth_tokens`. There should be one document, and it should have an `access_token` (but no `refresh_token`). Copy and paste it into the following terminal command:

```bash
curl -d -X -POST --header "Content-type:application/x-www-form-urlencoded" \
        https://oauth2.googleapis.com/revoke?token=your-token-goes-here
```
## Re-auth your app
_Now_ you need to go back to the oauth endpoint and re-authorize. When you're done, you should have a document in your `auth.auth_tokens` collection _with_ a `refresh_token`. You're good to go!